### PR TITLE
Fixed deadlock caused by an alien code invocation under a lock

### DIFF
--- a/src/main/java/com/github/signalr4j/client/Connection.java
+++ b/src/main/java/com/github/signalr4j/client/Connection.java
@@ -558,8 +558,8 @@ public class Connection implements ConnectionBase {
             mMessageId = null;
             mTransport = null;
 
-            onClosed();
         }
+        onClosed();
     }
 
     @Override


### PR DESCRIPTION
The SignalR library invoke an observer notification under lock which lead to improper order during locks acquisition and may result in a deadlock.
Consider a part of an application thread-dump:
```
Found one Java-level deadlock:
=============================
"pool-56-thread-1":
  waiting to lock monitor 0x00000000027d4370 (object 0x00000000cd4ce048, a org.java_websocket.WebSocketImpl),
  which is held by "Timer-109"
"Timer-109":
  waiting to lock monitor 0x0000000000e78ea0 (object 0x00000000cd4cd1c0, a java.lang.Object),
  which is held by "pool-56-thread-1"

Java stack information for the threads listed above:
===================================================
"pool-56-thread-1":
	at org.java_websocket.WebSocketImpl.close(WebSocketImpl.java:416)
	- waiting to lock <0x00000000cd4ce048> (a org.java_websocket.WebSocketImpl)
	at org.java_websocket.WebSocketImpl.close(WebSocketImpl.java:569)
	at org.java_websocket.client.WebSocketClient.close(WebSocketClient.java:188)
	at com.github.signalr4j.client.transport.WebsocketTransport$2.run(WebsocketTransport.java:194)
	at com.github.signalr4j.client.Connection.onClosed(Connection.java:810)
	at com.github.signalr4j.client.hubs.HubConnection.onClosed(HubConnection.java:164)
	at com.github.signalr4j.client.Connection.disconnect(Connection.java:561)
	- locked <0x00000000cd4cd1c0> (a java.lang.Object)
	at com.github.signalr4j.client.Connection$9.run(Connection.java:680)
	at com.github.signalr4j.client.HeartbeatMonitor$1.run(HeartbeatMonitor.java:74)
	- locked <0x00000000cd4a3ea0> (a java.lang.Object)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
"Timer-109":
	at com.github.signalr4j.client.Connection.disconnect(Connection.java:518)
	- waiting to lock <0x00000000cd4cd1c0> (a java.lang.Object)
	at com.github.signalr4j.client.Connection.onError(Connection.java:796)
	at com.github.signalr4j.client.transport.WebsocketTransport$1.onClose(WebsocketTransport.java:134)
	at org.java_websocket.client.WebSocketClient.onWebsocketClose(WebSocketClient.java:391)
	at org.java_websocket.WebSocketImpl.closeConnection(WebSocketImpl.java:504)
	- locked <0x00000000cd4ce048> (a org.java_websocket.WebSocketImpl)
	at org.java_websocket.WebSocketImpl.closeConnection(WebSocketImpl.java:515)
	at org.java_websocket.AbstractWebSocket$1.run(AbstractWebSocket.java:150)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)
```