### PR TITLE
Fixed deadlock at disconnecting and setted Reconnecting state

### DIFF
--- a/src/main/java/com/github/signalr4j/client/Connection.java
+++ b/src/main/java/com/github/signalr4j/client/Connection.java
@@ -581,6 +581,8 @@ public class Connection implements ConnectionBase {
      * Triggers the Reconnecting event
      */
     protected void onReconnecting() {
+        changeState(ConnectionState.Connected, ConnectionState.Reconnecting);
+
         if (mOnReconnecting != null) {
             mOnReconnecting.run();
         }
@@ -652,7 +654,6 @@ public class Connection implements ConnectionBase {
 
                 mTransport.abort(this);
 
-                changeState(ConnectionState.Connected, ConnectionState.Reconnecting);
                 onReconnecting();
             }
 

--- a/src/main/java/com/github/signalr4j/client/http/java/NetworkRunnable.java
+++ b/src/main/java/com/github/signalr4j/client/http/java/NetworkRunnable.java
@@ -101,6 +101,7 @@ class NetworkRunnable implements Runnable {
     void closeStreamAndConnection() {
 
         try {
+
             if (mConnection != null) {
                 mConnection.disconnect();
             }
@@ -124,6 +125,10 @@ class NetworkRunnable implements Runnable {
         URL url = new URL(request.getUrl());
         
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        // the timeout needs for right disconnection.
+        // without it when disconnect() calls at NetworkRunnable.closeStreamAndConnection()
+        // there is the deadlock occurred at StreamResponse.readLine()
+        connection.setReadTimeout(15 * 1000);
         connection.setConnectTimeout(15 * 1000);
         connection.setRequestMethod(request.getVerb());
 


### PR DESCRIPTION
If you start the application, it successfully connects to a server via signalr4j, but then you disconnect the app from the network, that signalr4j starts trying to reconnect.
But:
1) state was not set to Reconnecting
2) if my app caught onReconnecting event and call com.github.signalr4j.client.Connection#stop, there is deadlock (see [dump.txt](https://github.com/signalr4j/signalr4j/files/2880021/dump.txt)) and my app freezes.