### PR TITLE
Wss httpproxy support

### DIFF
--- a/src/main/java/com/github/signalr4j/client/transport/WebsocketTransport.java
+++ b/src/main/java/com/github/signalr4j/client/transport/WebsocketTransport.java
@@ -24,6 +24,7 @@ import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -191,14 +192,14 @@ public class WebsocketTransport extends HttpClientTransport {
 			}
 		};
 
-		if (isSsl) {
-			SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
-			try {
-				mWebSocketClient.setSocket(factory.createSocket());
-			} catch (IOException e1) {
-				e1.printStackTrace();
-			}
-		}
+    try {
+      List<Proxy> proxies = ProxySelector.getDefault().select(new URI(connection.getUrl()));
+      Proxy proxy = proxies.isEmpty() ? Proxy.NO_PROXY : proxies.get(0);
+      mWebSocketClient.setProxy(proxy);
+    } catch (URISyntaxException e) {
+      log(e);
+      e.printStackTrace();
+    }
 
 		mWebSocketClient.connect();
 

--- a/src/main/java/com/github/signalr4j/client/transport/WebsocketTransport.java
+++ b/src/main/java/com/github/signalr4j/client/transport/WebsocketTransport.java
@@ -21,7 +21,6 @@ import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.*;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -85,8 +84,6 @@ public class WebsocketTransport extends HttpClientTransport {
 		requestParams.put("messageId", connection.getMessageId());
 		requestParams.put("transport", getName());
 
-		boolean isSsl = false;
-
 //      Error on API < 24
 //		String url = requestParams.keySet().stream()
 //				.map(key -> key + "=" + encodeValue(requestParams.get(key)))
@@ -111,10 +108,6 @@ public class WebsocketTransport extends HttpClientTransport {
 
 		if (connection.getQueryString() != null) {
 			url += "&" + connection.getQueryString();
-		}
-
-		if (url.startsWith(SECURE_WEBSOCKET_SCHEME)) {
-			isSsl = true;
 		}
 
 		mConnectionFuture = new UpdateableCancellableFuture<Void>(null);


### PR DESCRIPTION
Hi,

First, thanks for maintaining this library which we use to connect to Bittrex from Java as Microsoft's version is not compatible with Bittrex signalR version.
 
We encountered an issue to support http proxy tunneling and I found this fix which works in our case.
I must say that I did not retest every combinations especially with non secure web sockets.

Please tell me if you have any remark.

Regards,
Benoit